### PR TITLE
Added 'server' login info to userInfo object from api.getSession()

### DIFF
--- a/src/app-helper.js
+++ b/src/app-helper.js
@@ -14,47 +14,47 @@ import { mapModel } from "../src/components/map/map-model";
 import storage from "./dataStore";
 import { initView } from "./index";
 import {
-  apiConfig,
-  userInfo
+   apiConfig,
+   userInfo
 } from "./dataStore/api-config";
 import {
-  resetAnimationOnFocus,
-  resetTransitionAnimation
+   resetAnimationOnFocus,
+   resetTransitionAnimation
 }
-  from "./utils/helper";
+   from "./utils/helper";
 
 export function initBeforeLogin() {
-  initDateKeeper();
+   initDateKeeper();
 }
 
 export function loginToSession(api) {
-  apiConfig.api = api;
-  return new Promise(resolve => {
-    apiConfig.api.getSession(session => {
-      userInfo.setUserInfo(session.userName, session.database, session.sessionId);
-      resolve();
-    });
-  });
+   apiConfig.api = api;
+   return new Promise(resolve => {
+      apiConfig.api.getSession((session, server) => {
+         userInfo.setUserInfo(session.userName, session.database, session.sessionId, server);
+         resolve();
+      });
+   });
 };
 
 export function initAfterLogin() {
-  storage.dateKeeper$.resume();
-  initView();
-  layerModel.initLayers();
-  mapModel.locateUserAndSetView();
-  resetAnimationOnFocus();
+   storage.dateKeeper$.resume();
+   initView();
+   layerModel.initLayers();
+   mapModel.locateUserAndSetView();
+   resetAnimationOnFocus();
 
-  initRealTimeFeedRunner();
-  initHistoricalFeedRunner();
+   initRealTimeFeedRunner();
+   initHistoricalFeedRunner();
 }
 
 export function handleBlur() {
-  storage.dateKeeper$.pause();
-  console.log("Blurred!");
+   storage.dateKeeper$.pause();
+   console.log("Blurred!");
 }
 
 export function handleFocus() {
-  storage.dateKeeper$.resume();
-  resetTransitionAnimation();
-  console.log("Focused!");
+   storage.dateKeeper$.resume();
+   resetTransitionAnimation();
+   console.log("Focused!");
 }

--- a/src/dataStore/api-config.js
+++ b/src/dataStore/api-config.js
@@ -1,19 +1,21 @@
-import { LOGRECORD, EXCEPTIONEVENT } from '../constants/feed-type-names';
+import { LOGRECORD, EXCEPTIONEVENT } from "../constants/feed-type-names";
 
 export const apiConfig = {
-  api: undefined,
-  feedTypesToGet: [LOGRECORD, EXCEPTIONEVENT],
-  resultsLimit: 60000,
+   api: undefined,
+   feedTypesToGet: [LOGRECORD, EXCEPTIONEVENT],
+   resultsLimit: 60000,
 };
 
 export const userInfo = {
-  userName: "",
-  database: "",
-  sessionId: "",
+   userName: "",
+   database: "",
+   sessionId: "",
+   server: "",
 
-  setUserInfo: (user, db, session) => {
-    userInfo.userName = user;
-    userInfo.database = db;
-    userInfo.sessionId = session;
-  }
+   setUserInfo: (user, db, session, server) => {
+      userInfo.userName = user;
+      userInfo.database = db;
+      userInfo.sessionId = session;
+      userInfo.server = server;
+   }
 };


### PR DESCRIPTION
Other Integrations may need the "server" property that is returned in the Geotab API call getSession(). 

SpartanLync uses this to validate add-in supplied credentials from our back-end service. 
We feel the "server" should be collected in the userInfo object along with db, username, sessionid.

As this part of the core code, we think this change should be contributed to the core code base.